### PR TITLE
feat: add unstoppable domains as a login option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
             "license": "AGPL-3.0",
             "dependencies": {
                 "@broxus/await-semaphore": "^0.1.5",
+                "@uauth/js": "^2.2.0",
+                "@uauth/web3modal": "^2.2.0",
                 "@walletconnect/web3-provider": "^1.7.5",
                 "abi-decoder": "^2.4.0",
                 "bignumber.js": "^9.0.2",
@@ -3402,6 +3404,74 @@
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@uauth/common": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@uauth/common/-/common-2.2.0.tgz",
+            "integrity": "sha512-A4z808W1eCpVuW9tbiSkSO3oy/g3rLUBtVCUq3gnsp2CX/8ea13Y++mWxzpGby2OZX76HVKuZD14Etpj5wProg==",
+            "peerDependencies": {
+                "@unstoppabledomains/resolution": "^7.0"
+            }
+        },
+        "node_modules/@uauth/js": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@uauth/js/-/js-2.2.0.tgz",
+            "integrity": "sha512-j31tF5QxRhj3bF2HfzlfH0dgaEOjxBFoCqZPe2M1i9DPgHgZEm6xS4D66rdYGQNuCsjqPfWo6aUG2xSbM0mQRg==",
+            "dependencies": {
+                "@uauth/common": "2.2.0",
+                "@unstoppabledomains/resolution": "^7.0",
+                "global": "^4.4.0",
+                "jose": "^4.5.0"
+            }
+        },
+        "node_modules/@uauth/web3modal": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@uauth/web3modal/-/web3modal-2.2.0.tgz",
+            "integrity": "sha512-PolkMAE/WFOp7en1nzZF/bvt5aM8rDmUEPoTOi0ElY+wz4L11+5eWUQBsIyRmH2we4S1w37zS6DM3AkYirFRZQ==",
+            "peerDependencies": {
+                "@uauth/js": "2.2.0",
+                "web3modal": "^1.9"
+            }
+        },
+        "node_modules/@unstoppabledomains/resolution": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/@unstoppabledomains/resolution/-/resolution-7.1.4.tgz",
+            "integrity": "sha512-GdXLpP+oRk4lLWMISo7g7gPyKoCONyLoQtYH6GVhXtyY9t+CeHJW2kZ/btcbXg0lmEO6PSr5yYOlDz4wRCq2RA==",
+            "dependencies": {
+                "@ethersproject/abi": "^5.0.1",
+                "bn.js": "^4.4.0",
+                "cross-fetch": "^3.1.4",
+                "elliptic": "^6.5.4",
+                "js-sha256": "^0.9.0",
+                "js-sha3": "^0.8.0"
+            }
+        },
+        "node_modules/@unstoppabledomains/resolution/node_modules/cross-fetch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+            "dependencies": {
+                "node-fetch": "2.6.7"
+            }
+        },
+        "node_modules/@unstoppabledomains/resolution/node_modules/node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@walletconnect/browser-utils": {
@@ -9825,6 +9895,19 @@
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
+        },
+        "node_modules/jose": {
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-4.9.0.tgz",
+            "integrity": "sha512-RgaqEOZLkVO+ViN3KkN44XJt9g7+wMveUv59sVLaTxONcUPc8ZpfqOCeLphVBZyih2dgkvZ0Ap1CNcokvY7Uyw==",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "node_modules/js-sha256": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
         },
         "node_modules/js-sha3": {
             "version": "0.8.0",
@@ -19393,6 +19476,60 @@
                 }
             }
         },
+        "@uauth/common": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@uauth/common/-/common-2.2.0.tgz",
+            "integrity": "sha512-A4z808W1eCpVuW9tbiSkSO3oy/g3rLUBtVCUq3gnsp2CX/8ea13Y++mWxzpGby2OZX76HVKuZD14Etpj5wProg==",
+            "requires": {}
+        },
+        "@uauth/js": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@uauth/js/-/js-2.2.0.tgz",
+            "integrity": "sha512-j31tF5QxRhj3bF2HfzlfH0dgaEOjxBFoCqZPe2M1i9DPgHgZEm6xS4D66rdYGQNuCsjqPfWo6aUG2xSbM0mQRg==",
+            "requires": {
+                "@uauth/common": "2.2.0",
+                "@unstoppabledomains/resolution": "^7.0",
+                "global": "^4.4.0",
+                "jose": "^4.5.0"
+            }
+        },
+        "@uauth/web3modal": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@uauth/web3modal/-/web3modal-2.2.0.tgz",
+            "integrity": "sha512-PolkMAE/WFOp7en1nzZF/bvt5aM8rDmUEPoTOi0ElY+wz4L11+5eWUQBsIyRmH2we4S1w37zS6DM3AkYirFRZQ==",
+            "requires": {}
+        },
+        "@unstoppabledomains/resolution": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/@unstoppabledomains/resolution/-/resolution-7.1.4.tgz",
+            "integrity": "sha512-GdXLpP+oRk4lLWMISo7g7gPyKoCONyLoQtYH6GVhXtyY9t+CeHJW2kZ/btcbXg0lmEO6PSr5yYOlDz4wRCq2RA==",
+            "requires": {
+                "@ethersproject/abi": "^5.0.1",
+                "bn.js": "^4.4.0",
+                "cross-fetch": "^3.1.4",
+                "elliptic": "^6.5.4",
+                "js-sha256": "^0.9.0",
+                "js-sha3": "^0.8.0"
+            },
+            "dependencies": {
+                "cross-fetch": {
+                    "version": "3.1.5",
+                    "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+                    "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+                    "requires": {
+                        "node-fetch": "2.6.7"
+                    }
+                },
+                "node-fetch": {
+                    "version": "2.6.7",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+                    "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+                    "requires": {
+                        "whatwg-url": "^5.0.0"
+                    }
+                }
+            }
+        },
         "@walletconnect/browser-utils": {
             "version": "1.7.5",
             "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.5.tgz",
@@ -24461,6 +24598,16 @@
                     }
                 }
             }
+        },
+        "jose": {
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-4.9.0.tgz",
+            "integrity": "sha512-RgaqEOZLkVO+ViN3KkN44XJt9g7+wMveUv59sVLaTxONcUPc8ZpfqOCeLphVBZyih2dgkvZ0Ap1CNcokvY7Uyw=="
+        },
+        "js-sha256": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
         },
         "js-sha3": {
             "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     },
     "dependencies": {
         "@broxus/await-semaphore": "^0.1.5",
+        "@uauth/js": "^2.2.0",
+        "@uauth/web3modal": "^2.2.0",
         "@walletconnect/web3-provider": "^1.7.5",
         "abi-decoder": "^2.4.0",
         "bignumber.js": "^9.0.2",

--- a/src/stores/EvmWalletService.ts
+++ b/src/stores/EvmWalletService.ts
@@ -4,6 +4,8 @@ import Web3 from 'web3'
 import Web3Modal from 'web3modal'
 import type { ICoreOptions } from 'web3modal'
 import BigNumber from 'bignumber.js'
+import * as UAuthWeb3Modal from '@uauth/web3modal'
+import UAuthSPA from '@uauth/js'
 
 import { BaseStore } from '@/stores/BaseStore'
 import {
@@ -601,6 +603,16 @@ export function useEvmWallet(): EvmWalletService {
                         },
                         package: WalletConnectProvider, // required
                     },
+                    'custom-uauth': {
+                        display: UAuthWeb3Modal.display,
+                        connector: UAuthWeb3Modal.connector,
+                        package: UAuthSPA,
+                        options: {
+                            clientID: "e3d0efd2-4666-4ea9-b58a-d97706718bea",
+                            redirectUri: "http://localhost:3000",
+                            scope: "openid wallet"
+                        }
+                    }
                 },
                 theme: 'dark',
             },


### PR DESCRIPTION
## This PR adds unstoppable domains as a login option

### Modified files
- add @uauth/js and @uauth/web3modal to package.json
- add unstoppable auth config to web3modal (src/stores/EvmWalletService.ts)

### Client config note
This PR works as is in production but if you wish to configure the login client by yourselves here are the docs for it:
[Unstoppable Domains Login Client Configuration](https://docs.unstoppabledomains.com/login-with-unstoppable/login-integration-guides/login-client-configuration/)
If you want to test it locally you have to set the redirect uri to http://localhost:3000 via the [login client config](https://docs.unstoppabledomains.com/login-with-unstoppable/login-integration-guides/login-client-configuration/)

An additional improvement on this PR could be to store the client ID in a .env file

### Video
https://user-images.githubusercontent.com/80958740/185914268-83138dbd-5d94-4029-a0fe-d98e88ba6b68.mp4


